### PR TITLE
HTTP Request Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ Temporary Items
 .apdisk
 
 README_old.md
+/bin/

--- a/plugin.xml
+++ b/plugin.xml
@@ -110,6 +110,7 @@
         </visibility>
       </property>
       <property key="ignoreCertificate" label="Disable certificate validation" type="boolean" description="Enable to allow connections via SSL even if the certificate on the target host is invalid or self-signed." default="false" />
+      <property key="httpSOAPHeader" label="Enable SOAPAction Header" type="boolean" description="Enable to send a SOAPAction HTTP header with your request. Useful if your application is returning 500 errors for valid requests." default="false" />
     </configuration>
   </extension>
   <extension point="com.dynatrace.diagnostics.pdk.monitor" id="com.dynatrace.diagnostics.plugin.SOAPMonitor.monitor" name="SOAP Monitor">

--- a/src/SOAP/SOAPMonitor.java
+++ b/src/SOAP/SOAPMonitor.java
@@ -45,6 +45,7 @@ public class SOAPMonitor implements Monitor, Migrator {
     private static final double MILLIS = 0.000001;
     private static final double SECS = 0.000000001;
     // configuration constants
+    private static final String CONFIG_SOAP_HTTP_HEADER = "httpSOAPHeader";
     private static final String CONFIG_PROTOCOL = "protocol";
     private static final String CONFIG_PATH = "path";
     private static final String CONFIG_HTTP_PORT = "httpPort";
@@ -121,6 +122,7 @@ public class SOAPMonitor implements Monitor, Migrator {
         boolean proxyAuth;
         String proxyUsername;
         String proxyPassword;
+        boolean httpSOAPHeader;
         long compareBytes;
     }
     private Config config;
@@ -433,7 +435,7 @@ public class SOAPMonitor implements Monitor, Migrator {
         }
         config.searchString = env.getConfigString(CONFIG_SEARCH_STRING) == null ? "" : env.getConfigString(CONFIG_SEARCH_STRING);
         config.compareBytes = env.getConfigLong(CONFIG_COMPARE_BYTES) == null ? 0 : env.getConfigLong(CONFIG_COMPARE_BYTES);
-
+        config.httpSOAPHeader = env.getConfigBoolean(CONFIG_SOAP_HTTP_HEADER) == null ? false : env.getConfigBoolean(CONFIG_SOAP_HTTP_HEADER);
         config.serverAuth = env.getConfigBoolean(CONFIG_SERVER_AUTH) == null ? false : env.getConfigBoolean(CONFIG_SERVER_AUTH);
         if (config.serverAuth) {
             config.serverUsername = env.getConfigString(CONFIG_SERVER_USERNAME);
@@ -477,7 +479,9 @@ public class SOAPMonitor implements Monitor, Migrator {
             httpMethod = new HeadMethod(url);
         } else if ("POST".equals(config.method)) {
             httpMethod = new PostMethod(url);
+            if (config.httpSOAPHeader) {
             httpMethod.setRequestHeader("soapaction", "");
+            }
             // set the POST data
             if (config.postData != null && config.postData.length() > 0) {
                 try {

--- a/src/SOAP/SOAPMonitor.java
+++ b/src/SOAP/SOAPMonitor.java
@@ -477,7 +477,7 @@ public class SOAPMonitor implements Monitor, Migrator {
             httpMethod = new HeadMethod(url);
         } else if ("POST".equals(config.method)) {
             httpMethod = new PostMethod(url);
-            httpMethod.setHeader("soapaction", "");
+            httpMethod.setRequestHeader("soapaction", "");
             // set the POST data
             if (config.postData != null && config.postData.length() > 0) {
                 try {

--- a/src/SOAP/SOAPMonitor.java
+++ b/src/SOAP/SOAPMonitor.java
@@ -477,6 +477,7 @@ public class SOAPMonitor implements Monitor, Migrator {
             httpMethod = new HeadMethod(url);
         } else if ("POST".equals(config.method)) {
             httpMethod = new PostMethod(url);
+            httpMethod.setHeader("soapaction", "");
             // set the POST data
             if (config.postData != null && config.postData.length() > 0) {
                 try {


### PR DESCRIPTION
Sometimes an application will throw a http 500 instead of return the SOAP data if you do not send a soapAction header in your request.

This pull creates a toggle option in the monitor config window that allows you to turn on/off the sending of the header.
